### PR TITLE
refactor: rename response data to body

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: false
-          custom_release_rules: 'build:patch,deps:patch'
+          custom_release_rules: 'build:patch,deps:patch,refactor:patch'
   publish-npm:
     name: Publish packages to NPM
     timeout-minutes: 2

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ const sdk = createSdk({ // SDK-wide options (common headers, ...)
 
 You're now ready to make type-safe API calls. The compiler will ensure that each
 method's inputs (request body, parameters, content type header...) match their
-type in the specification. The response (data and code) is also extensively
+type in the specification. The response (body and code) is also extensively
 type-checked taking into account the request's `accept` header.
 
 ```typescript
 const res = await sdk.GetAccount();
 switch (res.code) { // Typed response code
   case 200:
-    console.log(res.data.capabilities); // Narrowed response data type
+    console.log(res.body.capabilities); // Narrowed response body type
     break;
   // ...
 }

--- a/examples/content-types/src/server.ts
+++ b/examples/content-types/src/server.ts
@@ -43,16 +43,16 @@ class Handler implements KoaHandlersFor<Operations> {
     }
     if (ctx.accepts(['application/json', 'text/csv']) === 'application/json') {
       // When the `type` field is omitted from the return value, the SDK's
-      // default is used (application/json here) and the `data` type-checked
+      // default is used (application/json here) and the `body` type-checked
       // against it.
-      return {data: table};
+      return {body: table};
     }
-    // When a `type` field is set, the `data` field must match exacty that
-    // content-type's expected type (`string` here). Setting `table` as data
+    // When a `type` field is set, the `body` field must match exactly that
+    // content-type's expected type (`string` here). Setting `table` as body
     // directly would fail for example.
     return {
       type: 'text/csv',
-      data: table.rows?.map((r) => r.join(',')).join('\n') ?? '',
+      body: table.rows?.map((r) => r.join(',')).join('\n') ?? '',
     };
   }
 
@@ -68,7 +68,7 @@ class Handler implements KoaHandlersFor<Operations> {
         table = {rows: ctx.request.body.split('\n').map((r) => r.split(','))};
     }
     // The compiler automatically checks for us that the switch statement above
-    // is exhautive (if it wasn't, it would throw an error saying `table` is
+    // is exhaustive (if it wasn't, it would throw an error saying `table` is
     // used before being defined). This guarantees that we aren't forgetting any
     // branches.
     const {id} = ctx.params;

--- a/examples/content-types/test/index.test.ts
+++ b/examples/content-types/test/index.test.ts
@@ -48,7 +48,7 @@ test('fetches missing table as JSON', async () => {
     headers: {accept: 'application/json'},
   });
   assert(res.code === 404);
-  expect(res.data).toBeUndefined();
+  expect(res.body).toBeUndefined();
 });
 
 describe('fetches existing table', () => {
@@ -61,8 +61,8 @@ describe('fetches existing table', () => {
   test('as JSON', async () => {
     const res = await sdk.getTable({params: {id: 'id4'}});
     assert(res.code === 200);
-    assertType<Schema<'Table'>>(res.data);
-    expect(res.data).toEqual(table);
+    assertType<Schema<'Table'>>(res.body);
+    expect(res.body).toEqual(table);
   });
 
   test('fetches tables as CSV', async () => {
@@ -71,8 +71,8 @@ describe('fetches existing table', () => {
       headers: {accept: 'text/csv'},
     });
     assert(res.code === 200);
-    assertType<string>(res.data);
-    expect(res.data).toEqual('r1,v1');
+    assertType<string>(res.body);
+    expect(res.body).toEqual('r1,v1');
   });
 });
 
@@ -83,10 +83,10 @@ test('fetches table using glob', async () => {
   });
   switch (res.code) {
     case 200:
-      expect<Schema<'Table'> | string>(res.data).toEqual('');
+      expect<Schema<'Table'> | string>(res.body).toEqual('');
       break;
     case 404:
-      expect<undefined>(res.data).toBeUndefined();
+      expect<undefined>(res.body).toBeUndefined();
       break;
   }
 });

--- a/examples/forms-and-files/src/server.ts
+++ b/examples/forms-and-files/src/server.ts
@@ -22,7 +22,7 @@ export async function createRouter(): Promise<Router> {
         // (save to a file, decode, etc.).
         const sha = await computeSha(ctx.request.body);
         // We now return the computed SHA to be sent back to the client.
-        return {type: 'text/plain', data: sha};
+        return {type: 'text/plain', body: sha};
       },
       uploadForm: async (ctx) => {
         // This operations accepts requests with form bodies, either as

--- a/examples/forms-and-files/test/index.test.ts
+++ b/examples/forms-and-files/test/index.test.ts
@@ -26,7 +26,7 @@ test('upload binary data', async () => {
     body: new Blob(['some-binary-data']),
   });
   assert(res.code === 200);
-  expect(res.data).toContain('a489'); // Computed SHA returned by the server
+  expect(res.body).toContain('a489'); // Computed SHA returned by the server
 });
 
 test('upload urlencoded form', async () => {

--- a/examples/json/src/server.ts
+++ b/examples/json/src/server.ts
@@ -23,23 +23,23 @@ export async function createRouter(): Promise<Router> {
         // the client).
         const pet = {id: pets.size + 1, ...ctx.request.body};
         pets.set(pet.id, pet);
-        // Data can be sent back by returning an object with status and data
+        // Data can be sent back by returning an object with status and body
         // properties. Both are type-checked against the OpenAPI specification.
-        return {status: 201, data: pet};
+        return {status: 201, body: pet};
       },
       listPets: (ctx) => {
         // Similarly to request bodies, parameters are validated and typed
         // automatically.
         const limit = ctx.params.limit ?? 10;
-        // A 200 status can be omitted when sending data.
-        return {data: [...pets.values()].slice(0, limit)};
+        // A 200 status can be omitted when sending a body.
+        return {body: [...pets.values()].slice(0, limit)};
       },
       showPetById: (ctx) => {
         const pet = pets.get(ctx.params.petId);
         // Returning just a number from a handler produces a response with that
         // number as status and no content. Importantly, the returned number is
         // type-checked, so returning 200 would fail here for example!
-        return pet ? {data: pet} : 404;
+        return pet ? {body: pet} : 404;
       },
       clearPets: () => {
         pets.clear();

--- a/examples/json/test/index.test.ts
+++ b/examples/json/test/index.test.ts
@@ -33,31 +33,31 @@ test('creates and fetches a pet', async () => {
   // useful since different codes typically have different response schemas, for
   // example successful response and errors. In this example we did not declare
   // any errors in our specification so their data's type is `unknown`.
-  assertType<Schema<'Pet'> | unknown>(createRes.data);
+  assertType<Schema<'Pet'> | unknown>(createRes.body);
   // However after asserting that our response is successful...
   assert(createRes.code === 201);
   // ...the response's data type is narrowed accordingly.
-  assertType<Schema<'Pet'>>(createRes.data);
+  assertType<Schema<'Pet'>>(createRes.body);
 
-  const petId = createRes.data.id;
+  const petId = createRes.body.id;
   const showRes = await sdk.showPetById({params: {petId}});
   // It is often convenient to switch on a response's possible codes to access
   // individually narrowed types.
   switch (showRes.code) {
     case 200:
-      assertType<Schema<'Pet'>>(showRes.data); // `data` is typed as `Pet` here
-      expect(showRes.data.name).toEqual('Fido');
+      assertType<Schema<'Pet'>>(showRes.body); // `body` is typed as `Pet` here
+      expect(showRes.body.name).toEqual('Fido');
       break;
     case 404:
       // We did not declare a body in our specification for 404 responses so it
       // is typed as `undefined`.
-      assertType<undefined>(showRes.data);
+      assertType<undefined>(showRes.body);
       break;
     default:
       // Bodies for undeclared response codes are typed as `unknown` since we do
       // not have any type information for them in the schema (ssee also the
       // invalid input test below).
-      assertType<unknown>(showRes.data);
+      assertType<unknown>(showRes.body);
   }
   expect.assertions(1);
 });
@@ -68,7 +68,7 @@ test('fetches a missing pet', async () => {
   const res = await sdk.showPetById({params: {petId: 123}});
 
   assert(res.code === 404);
-  assertType<undefined>(res.data);
+  assertType<undefined>(res.body);
 });
 
 test('list no pets', async () => {
@@ -77,8 +77,8 @@ test('list no pets', async () => {
   const res = await sdk.listPets();
 
   assert(res.code === 200);
-  assertType<ReadonlyArray<Schema<'Pet'>>>(res.data);
-  expect(res.data).toEqual([]);
+  assertType<ReadonlyArray<Schema<'Pet'>>>(res.body);
+  expect(res.body).toEqual([]);
 });
 
 test('handles invalid input', async () => {
@@ -89,8 +89,8 @@ test('handles invalid input', async () => {
 
   assert(res.raw.status === 400);
   // Since we didn't declare 400 error responses in this example's
-  // specification, its data's type is left `unknown`. We can still access its
+  // specification, its body's type is left `unknown`. We can still access its
   // value though: in this case we know that it is a string containing the
   // relevant error message.
-  expect(res.data).contains('Invalid body');
+  expect(res.body).contains('Invalid body');
 });

--- a/examples/smart-streaming/README.md
+++ b/examples/smart-streaming/README.md
@@ -15,7 +15,7 @@ standard responses otherwise.
     case 200:
       // In the unary case, data is available (only) once the call completes as
       // a list of messages.
-      for (const processed of unary.data) {
+      for (const processed of unary.body) {
         // ...
       }
     // ...
@@ -36,7 +36,7 @@ standard responses otherwise.
       // Response data is now available incrementally and automatically typed as
       // an `AsyncIterable`! Processing it in real time is as easy as using an
       // asynchronous loop.
-      for await (const processed of streaming.data) {
+      for await (const processed of streaming.body) {
         // ...
       }
     // ...

--- a/examples/smart-streaming/src/server.ts
+++ b/examples/smart-streaming/src/server.ts
@@ -29,34 +29,34 @@ export async function messagesRouter(): Promise<Router> {
 
         if (ctx.accepts('application/json-seq')) {
           // The client accepts streaming responses. We can directly return an
-          // `AsyncIterable` of messages as data. Each message will be sent back
+          // `AsyncIterable` of messages as body. Each message will be sent back
           // to the client as it becomes available here.
-          return {type: 'application/json-seq', data: processedMessages()};
+          return {type: 'application/json-seq', body: processedMessages()};
         }
         // Otherwise the client only accepts unary responses. We wait for all
         // messages to be processed locally to be able to gather the entire
         // response and send it back.
-        const data: Schema<'Message'>[] = [];
+        const body: Schema<'Message'>[] = [];
         for await (const msg of processedMessages()) {
-          data.push(msg);
+          body.push(msg);
         }
-        return {type: 'application/json', data};
+        return {type: 'application/json', body};
       },
       ingestMessages: async (ctx) => {
         // The body of a request with a streaming type is a standard
         // `AsyncIterable`. It can for example be consumed via an asynchronous
         // loop, which will yield inputs as soon as they are received.
-        let data = 0;
+        let body = 0;
         for await (const msg of ctx.request.body) {
-          data += msg.contents.length;
+          body += msg.contents.length;
         }
-        return {data};
+        return {body};
       },
       echoMessages: (ctx) => {
         // Since streaming request bodies are also typed as `AsyncIterable`
-        // instances so we can simply return it as data to echo each message to
+        // instances so we can simply return it as body to echo each message to
         // the client right as it is received here!
-        return {type: 'application/json-seq', data: ctx.request.body};
+        return {type: 'application/json-seq', body: ctx.request.body};
       },
     },
   });

--- a/examples/smart-streaming/test/index.test.ts
+++ b/examples/smart-streaming/test/index.test.ts
@@ -30,7 +30,7 @@ describe('smart streaming', () => {
   test('unary', async () => {
     const res = await sdk.processMessages({body: messages});
     assert(res.code === 200);
-    expect(res.data).toEqual([{contents: 'HI'}, {contents: 'THERE'}]);
+    expect(res.body).toEqual([{contents: 'HI'}, {contents: 'THERE'}]);
   });
 
   test('streaming', async () => {
@@ -40,7 +40,7 @@ describe('smart streaming', () => {
     });
     assert(res.code === 200);
     const contents: string[] = [];
-    for await (const msg of res.data) {
+    for await (const msg of res.body) {
       contents.push(msg.contents);
     }
     expect(contents).toEqual(['HI', 'THERE']);
@@ -61,7 +61,7 @@ test('client streaming', async () => {
     headers: {'content-type': 'application/json-seq'},
   });
   assert(res.code === 200);
-  expect(res.data).toEqual(10);
+  expect(res.body).toEqual(10);
 });
 
 test('bi-directional streaming', async () => {
@@ -83,7 +83,7 @@ test('bi-directional streaming', async () => {
   assert(res.code === 200);
 
   const contents: string[] = [];
-  for await (const msg of res.data) {
+  for await (const msg of res.body) {
     contents.push(msg.contents);
   }
   expect(contents).toEqual(['hey', 'hey']);

--- a/packages/abaca-cli/README.md
+++ b/packages/abaca-cli/README.md
@@ -34,7 +34,7 @@ boilerplate.
   const res = await sdk.someOperation(/* Request body, parameters, ... */);
   switch (res.code) {
     case 200:
-      doSomething(res.data); // Narrowed response data
+      doSomething(res.body); // Narrowed response body
       break;
     // ...
   }
@@ -63,7 +63,7 @@ const res = await sdk.doSomething({
   options: {/* ... */}, // 5
 });
 if (res.code === 200) { // 6
-  return res.data; // 7
+  return res.body; // 7
 }
 ```
 
@@ -135,10 +135,10 @@ operation defined [here][tables]:
 const res = await sdk.downloadTable({params: {id: 'my-id'}});
 switch (res.code) {
   case 200:
-    res.data; // Narrowed type: `Table`
+    res.body; // Narrowed type: `Table`
     break;
   case 404:
-    res.data; // Narrowed type: `undefined`
+    res.body; // Narrowed type: `undefined`
     break;
 }
 ```
@@ -152,10 +152,10 @@ const res = await sdk.downloadTable({
 });
 switch (res.code) {
   case 200:
-    res.data; // Narrowed type: `string`
+    res.body; // Narrowed type: `string`
     break;
   case 404:
-    res.data; // Narrowed type: `undefined`
+    res.body; // Narrowed type: `undefined`
     break;
 }
 ```
@@ -169,7 +169,7 @@ const res = await sdk.downloadTable({
   headers: {accept: '*/*'},
 });
 if (res.code === 200) {
-  res.data; // Narrowed type: `Table | string`
+  res.body; // Narrowed type: `Table | string`
 }
 ```
 
@@ -234,7 +234,7 @@ const res = await sdk.runSomeOperation({
 
 switch (res.code) {
   case 200:
-    res.data; // Narrowed (based on code and `accept` header)
+    res.body; // Narrowed (based on code and `accept` header)
   // ...
 }
 ```

--- a/packages/abaca-cli/test/pets.test.ts
+++ b/packages/abaca-cli/test/pets.test.ts
@@ -42,7 +42,7 @@ describe('pets', () => {
     const res = await sdk.listPets();
     switch (res.code) {
       case 200:
-        expect<ReadonlyArray<Schema<'Pet'>>>(res.data).toEqual([]);
+        expect<ReadonlyArray<Schema<'Pet'>>>(res.body).toEqual([]);
         break;
       default:
         throw unexpected(res);
@@ -53,7 +53,7 @@ describe('pets', () => {
     const res = await sdk.listPets({});
     switch (res.code) {
       case 200:
-        expect<ReadonlyArray<Schema<'Pet'>>>(res.data).toEqual([]);
+        expect<ReadonlyArray<Schema<'Pet'>>>(res.body).toEqual([]);
         break;
       default:
         throw unexpected(res);
@@ -69,7 +69,7 @@ describe('pets', () => {
       case '2XX':
         throw unexpected(res);
       default:
-        expect<number>(res.data.code).toEqual(400);
+        expect<number>(res.body.code).toEqual(400);
     }
   });
 
@@ -83,7 +83,7 @@ describe('pets', () => {
       default:
         expect(res.code).toEqual('default');
         expect(res.raw.status).toEqual(406);
-        expect<undefined>(res.data).toBeUndefined();
+        expect<undefined>(res.body).toBeUndefined();
     }
   });
 
@@ -98,7 +98,7 @@ describe('pets', () => {
       default:
         expect(res.code).toEqual('default');
         expect(res.raw.status).toEqual(406);
-        expect<Schema<'Error'>>(res.data).toBeUndefined();
+        expect<Schema<'Error'>>(res.body).toBeUndefined();
     }
   });
 
@@ -117,15 +117,15 @@ describe('pets', () => {
 
   test('optional query parameter', async () => {
     const res = await sdk.listPets({params: {limit: 1}});
-    let data: ResponseData<'listPets', 200> | undefined;
+    let body: ResponseData<'listPets', 200> | undefined;
     switch (res.code) {
       case 200:
-        data = res.data;
+        body = res.body;
         break;
       default:
         throw unexpected(res);
     }
-    expect(data).toEqual([]);
+    expect(body).toEqual([]);
   });
 
   test('required body', async () => {
@@ -136,12 +136,12 @@ describe('pets', () => {
     if (cres.code !== 201) {
       throw unreachable();
     }
-    const id: string = cres.data;
+    const id: string = cres.body;
     const body: RequestBody<'updatePetTag'> = {name: 'a'};
     const res = await sdk.updatePetTag({body, params: {petId: id}});
     switch (res.code) {
       case 200:
-        expect<Schema<'Pet'>>(res.data).toEqual({id, name: 'a', tag: 't'});
+        expect<Schema<'Pet'>>(res.body).toEqual({id, name: 'a', tag: 't'});
         break;
       default:
         throw unexpected(res);
@@ -157,7 +157,7 @@ describe('pets', () => {
     });
     switch (res.code) {
       case 200:
-        expect(res.data).toEqual([]);
+        expect(res.body).toEqual([]);
         break;
       default:
         throw unexpected(res);
@@ -168,10 +168,10 @@ describe('pets', () => {
     const res = await sdk.getPetAge({params: {petId: 'hi'}});
     switch (res.code) {
       case 200:
-        assertType<number>(res.data);
+        assertType<number>(res.body);
         throw unexpected(res);
       case 400:
-        assertType<string>(res.data);
+        assertType<string>(res.body);
         throw unexpected(res);
       case 404:
         break;
@@ -189,13 +189,13 @@ describe('pets', () => {
     });
     switch (res.code) {
       case 200:
-        assertType<number>(res.data);
+        assertType<number>(res.body);
         throw unexpected(res);
       case 400:
-        assertType<undefined>(res.data);
+        assertType<undefined>(res.body);
         throw unexpected(res);
       case 404:
-        assertType<undefined>(res.data);
+        assertType<undefined>(res.body);
         break;
       case 'default':
         throw unexpected(res);
@@ -211,13 +211,13 @@ describe('pets', () => {
     });
     switch (res.code) {
       case 200:
-        assertType<undefined>(res.data);
+        assertType<undefined>(res.body);
         throw unexpected(res);
       case 400:
-        assertType<string>(res.data);
+        assertType<string>(res.body);
         throw unexpected(res);
       case 404:
-        assertType<undefined>(res.data);
+        assertType<undefined>(res.body);
         break;
       case 'default':
         throw unexpected(res);

--- a/packages/abaca-cli/test/tables.test.ts
+++ b/packages/abaca-cli/test/tables.test.ts
@@ -53,10 +53,10 @@ describe('tables', () => {
     });
     switch (res.code) {
       case 200:
-        expect<Schema<'Table'>>(res.data).toEqual([]);
+        expect<Schema<'Table'>>(res.body).toEqual([]);
         break;
       case 404:
-        expect<undefined>(res.data).toBeUndefined();
+        expect<undefined>(res.body).toBeUndefined();
         break;
     }
   });
@@ -68,10 +68,10 @@ describe('tables', () => {
     });
     switch (res.code) {
       case 200:
-        expect<string>(res.data).toEqual('');
+        expect<string>(res.body).toEqual('');
         break;
       case 404:
-        expect<undefined>(res.data).toBeUndefined();
+        expect<undefined>(res.body).toBeUndefined();
         break;
     }
   });
@@ -83,10 +83,10 @@ describe('tables', () => {
     });
     switch (res.code) {
       case 200:
-        expect<Schema<'Table'> | string>(res.data).toEqual('');
+        expect<Schema<'Table'> | string>(res.body).toEqual('');
         break;
       case 404:
-        expect<undefined>(res.data).toBeUndefined();
+        expect<undefined>(res.body).toBeUndefined();
         break;
     }
   });
@@ -98,10 +98,10 @@ describe('tables', () => {
     });
     switch (res.code) {
       case 200:
-        expect<Schema<'Table'> | string>(res.data).toEqual('');
+        expect<Schema<'Table'> | string>(res.body).toEqual('');
         break;
       case 404:
-        expect<undefined>(res.data).toBeUndefined();
+        expect<undefined>(res.body).toBeUndefined();
         break;
     }
   });
@@ -113,10 +113,10 @@ describe('tables', () => {
     });
     switch (res.code) {
       case 200:
-        expect<Schema<'Table'>>(res.data).toEqual('');
+        expect<Schema<'Table'>>(res.body).toEqual('');
         break;
       case 404:
-        expect<undefined>(res.data).toBeUndefined();
+        expect<undefined>(res.body).toBeUndefined();
         break;
     }
   });

--- a/packages/abaca-koa/src/router/types.ts
+++ b/packages/abaca-koa/src/router/types.ts
@@ -41,12 +41,14 @@ type KoaContext<O extends OperationType, S = {}> = Koa.ParameterizedContext<
   ContextFor<O>
 >;
 
-type MaybeBodyContent<O extends OperationType> = Lookup<
+type MaybeRequestBodyContent<O extends OperationType> = Lookup<
   Lookup<O, 'requestBody'>,
   'content'
 >;
 
-type ContextFor<O extends OperationType> = ContextForBody<MaybeBodyContent<O>> &
+type ContextFor<O extends OperationType> = ContextForBody<
+  MaybeRequestBodyContent<O>
+> &
   ContextWithParams<OperationParams<O>>;
 
 type ContextForBody<B> = [B] extends [undefined]
@@ -133,21 +135,21 @@ export type KoaValuesFor<
 };
 
 type KoaValue<O, M extends MimeType> =
-  O extends OperationType<infer R> ? EmptyData<R> | NonEmptyData<R, M> : never;
+  O extends OperationType<infer R> ? EmptyBody<R> | NonEmptyBody<R, M> : never;
 
-type EmptyData<R extends ResponsesType> = Values<{
+type EmptyBody<R extends ResponsesType> = Values<{
   [C in keyof R]: Get<R[C], 'content'> extends never
     ? StatusesMatching<C>
     : never;
 }>;
 
-type NonEmptyData<R extends ResponsesType, M extends MimeType> = Values<{
-  [C in keyof R]: DataForCode<C, Get<R[C], 'content'>, keyof R, M>;
+type NonEmptyBody<R extends ResponsesType, M extends MimeType> = Values<{
+  [C in keyof R]: ResponseBodyForCode<C, Get<R[C], 'content'>, keyof R, M>;
 }>;
 
-type DataForCode<C, D, X, M> = Values<{
+type ResponseBodyForCode<C, D, X, M> = Values<{
   [K in keyof D]: {
-    readonly data:
+    readonly body:
       | D[K]
       | (D[K] extends Blob | string ? Buffer | stream.Readable : never);
   } & WithType<K, M> &

--- a/packages/abaca-koa/test/proxy.test.ts
+++ b/packages/abaca-koa/test/proxy.test.ts
@@ -19,7 +19,7 @@ describe('operation proxy', () => {
 
     const readRouter = createOperationsRouter<Operations>({
       document,
-      handlers: {getTable: () => (table ? {data: table} : 404)},
+      handlers: {getTable: () => (table ? {body: table} : 404)},
     });
     readServer = await startApp(new Koa().use(readRouter.routes()));
 
@@ -66,7 +66,7 @@ describe('operation proxy', () => {
     const setRes = await sdk.setTable({params: {id: '1'}, body: table});
     expect(setRes).toMatchObject({code: 204});
     const getRes = await sdk.getTable({params: {id: '1'}});
-    expect(getRes).toMatchObject({code: 200, data: table});
+    expect(getRes).toMatchObject({code: 200, body: table});
   });
 
   test('calls prepare', async () => {

--- a/packages/abaca-koa/test/router/pets.test.ts
+++ b/packages/abaca-koa/test/router/pets.test.ts
@@ -41,19 +41,19 @@ describe('pets', async () => {
       listPets: async (ctx) => {
         const limit = ctx.params.limit ?? 2;
         if (limit! > 2) {
-          return {status: 400, data: {code: 400, message: 'Limit too high'}};
+          return {status: 400, body: {code: 400, message: 'Limit too high'}};
         }
-        return {data: pets};
+        return {body: pets};
       },
     });
 
     const res1 = await sdk.listPets();
-    expect(res1).toMatchObject({code: 200, data: []});
+    expect(res1).toMatchObject({code: 200, body: []});
 
     const res2 = await sdk.listPets({params: {limit: 3}});
     expect(res2).toMatchObject({
       code: 'default',
-      data: {code: 400},
+      body: {code: 400},
       raw: {status: 400},
     });
   });
@@ -63,7 +63,7 @@ describe('pets', async () => {
     await resetHandlers({
       createPet: (ctx) => {
         pet = {id: 11, ...ctx.request.body};
-        return {status: 201, type: 'text/plain', data: 'ok'};
+        return {status: 201, type: 'text/plain', body: 'ok'};
       },
     });
 
@@ -71,7 +71,7 @@ describe('pets', async () => {
       body: {name: 'n1', tag: 't1'},
       headers: {accept: '*/*'},
     });
-    expect(res1).toMatchObject({code: 201, data: 'ok'});
+    expect(res1).toMatchObject({code: 201, body: 'ok'});
 
     const res2 = await sdk.createPet({
       body: {name: 'n1', tag: 't2'},

--- a/packages/abaca-koa/test/router/snippets.test.ts
+++ b/packages/abaca-koa/test/router/snippets.test.ts
@@ -37,7 +37,7 @@ describe('snippets', async () => {
         [JSON_SEQ_MIME_TYPE]: jsonSeqDecoder(),
       },
       encoders: {
-        [FORM_MIME_TYPE]: (data) => qs.stringify(data),
+        [FORM_MIME_TYPE]: (body) => qs.stringify(body),
         [JSON_SEQ_MIME_TYPE]: jsonSeqEncoder(),
       },
     });
@@ -54,7 +54,7 @@ describe('snippets', async () => {
   test('echos binary data', async () => {
     await resetHandlers({
       '/binary-echo#post': (ctx) => {
-        return {type: 'application/octet-stream', data: ctx.request.body};
+        return {type: 'application/octet-stream', body: ctx.request.body};
       },
     });
 
@@ -66,13 +66,13 @@ describe('snippets', async () => {
       body: new Blob(['abc']),
     });
     assert(res.code === 200);
-    expect(await res.data.text()).toEqual('abc');
+    expect(await res.body.text()).toEqual('abc');
   });
 
   test('echos object data', async () => {
     await resetHandlers({
       '/object-echo#post': (ctx) => {
-        return {type: 'application/json-seq', data: ctx.request.body};
+        return {type: 'application/json-seq', body: ctx.request.body};
       },
     });
 
@@ -85,7 +85,7 @@ describe('snippets', async () => {
       body: toAsyncIterable(messages),
     });
     assert(res.code === 200);
-    expect(await fromAsyncIterable(res.data)).toEqual(messages);
+    expect(await fromAsyncIterable(res.body)).toEqual(messages);
   });
 
   test('uploads URL encoded form', async () => {
@@ -175,7 +175,7 @@ describe('snippets', async () => {
       '/custom-binary-response#get': async () => {
         return {
           type: 'application/vnd.opvious.example',
-          data: new Blob(['123']),
+          body: new Blob(['123']),
         };
       },
     });
@@ -184,7 +184,7 @@ describe('snippets', async () => {
       headers: {accept: '*/*'},
     });
     assert(res.code === 200);
-    const text = await res.data.text();
+    const text = await res.body.text();
     expect(text).toEqual('123');
   });
 });

--- a/packages/abaca-koa/test/router/tables.test.ts
+++ b/packages/abaca-koa/test/router/tables.test.ts
@@ -78,7 +78,7 @@ describe('tables', async () => {
 
     const updateRes = await sdk.setTable({
       params: {id},
-      body: {rows: getRes1.data.rows.slice(1)},
+      body: {rows: getRes1.body.rows.slice(1)},
     });
     expect(updateRes).toMatchObject({code: 204, raw: {status: 204}});
 
@@ -86,12 +86,12 @@ describe('tables', async () => {
       params: {id},
       headers: {accept: 'text/csv'},
     });
-    expect(getRes2).toMatchObject({code: 200, data: 'b,2'});
+    expect(getRes2).toMatchObject({code: 200, body: 'b,2'});
   });
 
   test('get missing', async () => {
     const res = await sdk.getTable({params: {id: 'unknown'}});
-    expect(res).toMatchObject({code: 404, data: undefined});
+    expect(res).toMatchObject({code: 404, body: undefined});
   });
 
   test('set invalid', async () => {
@@ -102,7 +102,7 @@ describe('tables', async () => {
     });
     expect(res).toMatchObject({
       code: 'default',
-      data: {error: {code: 'ERR_INVALID_REQUEST'}},
+      body: {error: {code: 'ERR_INVALID_REQUEST'}},
       raw: {status: 400},
     });
   });
@@ -126,7 +126,7 @@ describe('tables', async () => {
       params: {id},
     });
     assert(getRes.code === 200, '');
-    const got = await fromAsyncIterable(getRes.data);
+    const got = await fromAsyncIterable(getRes.body);
     expect(got).toEqual(rows.map((r) => ({kind: 'row', row: r})));
   });
 });
@@ -151,11 +151,11 @@ class Handler implements sut.KoaHandlersFor<Operations> {
       ctx.accepts(['application/json', 'application/json-seq', 'text/csv'])
     ) {
       case 'application/json':
-        return {data: table};
+        return {body: table};
       case 'application/json-seq':
         return {
           type: 'application/json-seq',
-          data: mapAsyncIterable(toAsyncIterable(table.rows), (r) => ({
+          body: mapAsyncIterable(toAsyncIterable(table.rows), (r) => ({
             kind: 'row',
             row: r,
           })),
@@ -163,7 +163,7 @@ class Handler implements sut.KoaHandlersFor<Operations> {
       case 'text/csv':
         return {
           type: 'text/csv',
-          data: table.rows?.map((r) => r.join(',')).join('\n') ?? '',
+          body: table.rows?.map((r) => r.join(',')).join('\n') ?? '',
         };
       default:
         throw unreachable();


### PR DESCRIPTION
This is consistent with the request side frees up the "data" term to be used for programmatic-usage types.