### PR TITLE
feat: widen Koa return types

### DIFF
--- a/packages/abaca-koa/src/router/index.ts
+++ b/packages/abaca-koa/src/router/index.ts
@@ -533,11 +533,12 @@ class Registry {
     const key = schemaId(oid, {kind: 'responseBody', contentType, code});
     const validate = this.cache.getSchema(key);
     assert(validate, 'Missing response schema', key);
+    // We always allow buffers and readable streams so that implementers can use
+    // an optimized handler implementation.
     if (
-      content.isBinary &&
-      (Buffer.isBuffer(data) ||
-        data instanceof stream.Readable ||
-        data instanceof Blob)
+      Buffer.isBuffer(data) ||
+      data instanceof stream.Readable ||
+      (content.isBinary && data instanceof Blob)
     ) {
       return;
     }

--- a/packages/abaca-koa/src/router/types.ts
+++ b/packages/abaca-koa/src/router/types.ts
@@ -151,7 +151,13 @@ type ResponseBodyForCode<C, D, X, M> = Values<{
   [K in keyof D]: {
     readonly body:
       | D[K]
-      | (D[K] extends Blob | string ? Buffer | stream.Readable : never);
+      // We don't augment the return type for async iterables to improve
+      // inference at call sites. The additional union prevents the type checker
+      // from correctly promoting literals into union discriminators for
+      // example (see `router/tables.test.ts#L158`).
+      | (D[K] extends AsyncIterable<unknown>
+          ? never
+          : Buffer | stream.Readable);
   } & WithType<K, M> &
     WithStatus<StatusesMatching<C, X>>;
 }>;

--- a/packages/abaca/src/sdk.ts
+++ b/packages/abaca/src/sdk.ts
@@ -1,9 +1,5 @@
 import {AsyncOrSync, Lookup} from './common.js';
-import {
-  ContentFormat,
-  MimeType,
-  ResponseCode,
-} from './operations.js';
+import {ContentFormat, MimeType, ResponseCode} from './operations.js';
 
 // Configuration
 


### PR DESCRIPTION
All non-(object-)streaming handlers can now return buffers and readable streams.